### PR TITLE
공통 모듈(common) 도입 및 기반 구조 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### secrets ###
+**/application*.yml
+**/.env
+.env

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+}
+
+dependencies {
+    // Web/API
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+}

--- a/common/src/main/java/kt/aivle/common/code/CommonResponseCode.java
+++ b/common/src/main/java/kt/aivle/common/code/CommonResponseCode.java
@@ -1,0 +1,38 @@
+package kt.aivle.common.code;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum CommonResponseCode implements DefaultCode {
+    // 성공
+    OK(HttpStatus.OK, true, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, true, "자원이 성공적으로 생성되었습니다."),
+    ACCEPTED(HttpStatus.ACCEPTED, true, "요청이 수락되었습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT, true, "내용 없음"),
+
+    // 실패
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, false,"요청한 리소스를 찾을 수 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, false, "요청이 충돌했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
+    private final boolean success;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return success;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/common/src/main/java/kt/aivle/common/code/DefaultCode.java
+++ b/common/src/main/java/kt/aivle/common/code/DefaultCode.java
@@ -1,0 +1,10 @@
+package kt.aivle.common.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface DefaultCode {
+    HttpStatus getHttpStatus();
+    boolean isSuccess();
+    String name();
+    String getMessage();
+}

--- a/common/src/main/java/kt/aivle/common/entity/BaseEntity.java
+++ b/common/src/main/java/kt/aivle/common/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package kt.aivle.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/common/src/main/java/kt/aivle/common/exception/BusinessException.java
+++ b/common/src/main/java/kt/aivle/common/exception/BusinessException.java
@@ -1,0 +1,24 @@
+package kt.aivle.common.exception;
+
+import kt.aivle.common.code.DefaultCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final DefaultCode code;
+
+    public BusinessException(DefaultCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+
+    public BusinessException(DefaultCode code, Throwable cause) {
+        super(code.getMessage(), cause);
+        this.code = code;
+    }
+
+    public BusinessException(DefaultCode code, String customMessage) {
+        super(customMessage);
+        this.code = code;
+    }
+}

--- a/common/src/main/java/kt/aivle/common/exception/FieldError.java
+++ b/common/src/main/java/kt/aivle/common/exception/FieldError.java
@@ -1,0 +1,4 @@
+package kt.aivle.common.exception;
+
+public record FieldError(String field, String message) {
+}

--- a/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package kt.aivle.common.exception;
+
+import kt.aivle.common.response.ApiResponse;
+import kt.aivle.common.response.ResponseUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+import static kt.aivle.common.code.CommonResponseCode.BAD_REQUEST;
+import static kt.aivle.common.code.CommonResponseCode.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final ResponseUtils responseUtils;
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("서버 예외 발생: {}", e.getMessage(), e); // 스택트레이스 포함 로깅
+        return responseUtils.build(INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.error("비즈니스 예외 발생: {}", e.toString(), e);
+        return responseUtils.build(e.getCode());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        log.error("필드 예외 발생: {}", e.toString(), e);
+        List<FieldError> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(err -> new FieldError(err.getField(), err.getDefaultMessage()))
+                .toList();
+        return responseUtils.build(BAD_REQUEST, errors);
+    }
+}
+
+
+

--- a/common/src/main/java/kt/aivle/common/response/ApiResponse.java
+++ b/common/src/main/java/kt/aivle/common/response/ApiResponse.java
@@ -1,0 +1,31 @@
+package kt.aivle.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import kt.aivle.common.code.DefaultCode;
+import kt.aivle.common.exception.FieldError;
+
+import java.util.List;
+
+@JsonPropertyOrder({"isSuccess", "message", "result", "errors"})
+public record ApiResponse<T>(
+        Boolean isSuccess,
+        String message,
+        T result,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        List<FieldError> errors
+) {
+    public static <T> ApiResponse<T> of(DefaultCode code, T result) {
+        return new ApiResponse<>(code.isSuccess(), code.getMessage(), result, null);
+    }
+
+    public static <T> ApiResponse<T> of(DefaultCode code, List<FieldError> errors) {
+        return new ApiResponse<>(code.isSuccess(), code.getMessage(), null, errors);
+    }
+
+    public static <T> ApiResponse<T> of(DefaultCode code, T result, List<FieldError> errors) {
+        return new ApiResponse<>(code.isSuccess(), code.getMessage(), result, errors);
+    }
+}
+
+

--- a/common/src/main/java/kt/aivle/common/response/ResponseUtils.java
+++ b/common/src/main/java/kt/aivle/common/response/ResponseUtils.java
@@ -1,0 +1,32 @@
+package kt.aivle.common.response;
+
+import kt.aivle.common.code.DefaultCode;
+import kt.aivle.common.exception.FieldError;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ResponseUtils {
+    public <T> ResponseEntity<ApiResponse<T>> build(DefaultCode code, T result) {
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.of(code, result));
+    }
+
+    public ResponseEntity<ApiResponse<Void>> build(DefaultCode code, List<FieldError> errors) {
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.of(code, errors));
+    }
+
+    public <T> ResponseEntity<ApiResponse<T>> build(DefaultCode code, T result, List<FieldError> errors) {
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.of(code, result, errors));
+    }
+
+    public ResponseEntity<ApiResponse<Void>> build(DefaultCode code) {
+        return build(code, (Void) null);
+    }
+}
+
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'marketing'
+include 'common'
 include 'auth-service'
-


### PR DESCRIPTION
### 주요 변경 사항
- common 모듈 build.gradle 추가 및 의존성 설정
- settings.gradle에 common 모듈 등록
- 공통 BaseEntity(Auditing 포함) 추가
- 글로벌 예외 처리 구조(BusinessException, DefaultCode, GlobalExceptionHandler) 도입
- 일관된 API 응답 포맷(ApiResponse, ResponseUtils) 및 ResponseFactory 패턴 적용
- 유효성 검증 에러(errors 필드) 지원 구조 추가

### 참고/특이사항
- 각 서비스 모듈은 common의 응답/예외/베이스 엔티티 구조를 상속해 사용 가능
- 상세 에러 메시지 및 코드 관리, 확장성 고려하여 설계함

Closes #1