### PR TITLE
[issue #3] Auth - 회원가입/로그인 정책 및 JWT 적용

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+}
+
+dependencies {
+    // 공통 모듈
+    implementation project(':common')
+
+    // Web/API
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // 보안·인증
+    implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // DB/JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // 요청 검증
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/auth-service/src/main/java/kt/aivle/auth/AuthServiceApplication.java
+++ b/auth-service/src/main/java/kt/aivle/auth/AuthServiceApplication.java
@@ -1,0 +1,11 @@
+package kt.aivle.auth;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {"kt.aivle.auth", "kt.aivle.common"})
+public class AuthServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AuthServiceApplication.class, args);
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
@@ -1,6 +1,7 @@
 package kt.aivle.auth.adapter.in.web;
 
 import jakarta.validation.Valid;
+import kt.aivle.auth.adapter.in.web.dto.LoginRequest;
 import kt.aivle.auth.adapter.in.web.dto.SignUpRequest;
 import kt.aivle.auth.application.port.in.AuthUseCase;
 import kt.aivle.common.response.ApiResponse;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static kt.aivle.common.code.CommonResponseCode.CREATED;
+import static kt.aivle.common.code.CommonResponseCode.OK;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -26,5 +28,11 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
         authUseCase.singUp(request.toCommand());
         return responseUtils.build(CREATED);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginRequest request) {
+        authUseCase.login(request.toCommand());
+        return responseUtils.build(OK);
     }
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
@@ -1,0 +1,30 @@
+package kt.aivle.auth.adapter.in.web;
+
+import jakarta.validation.Valid;
+import kt.aivle.auth.adapter.in.web.dto.SignUpRequest;
+import kt.aivle.auth.application.port.in.AuthUseCase;
+import kt.aivle.common.response.ApiResponse;
+import kt.aivle.common.response.ResponseUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static kt.aivle.common.code.CommonResponseCode.CREATED;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthUseCase authUseCase;
+    private final ResponseUtils responseUtils;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
+        authUseCase.singUp(request.toCommand());
+        return responseUtils.build(CREATED);
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
@@ -1,6 +1,7 @@
 package kt.aivle.auth.adapter.in.web;
 
 import jakarta.validation.Valid;
+import kt.aivle.auth.adapter.in.web.dto.AuthResponse;
 import kt.aivle.auth.adapter.in.web.dto.LoginRequest;
 import kt.aivle.auth.adapter.in.web.dto.SignUpRequest;
 import kt.aivle.auth.application.port.in.AuthUseCase;
@@ -25,14 +26,14 @@ public class AuthController {
     private final ResponseUtils responseUtils;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody SignUpRequest request) {
-        authUseCase.singUp(request.toCommand());
-        return responseUtils.build(CREATED);
+    public ResponseEntity<ApiResponse<AuthResponse>> signUp(@Valid @RequestBody SignUpRequest request) {
+        AuthResponse response = authUseCase.signUp(request.toCommand());
+        return responseUtils.build(CREATED, response);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginRequest request) {
-        authUseCase.login(request.toCommand());
-        return responseUtils.build(OK);
+    public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
+        AuthResponse response = authUseCase.login(request.toCommand());
+        return responseUtils.build(OK, response);
     }
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/AuthResponse.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/AuthResponse.java
@@ -1,0 +1,7 @@
+package kt.aivle.auth.adapter.in.web.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AuthResponse(String accessToken, long accessTokenExpiration) {
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/LoginRequest.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/LoginRequest.java
@@ -1,0 +1,22 @@
+package kt.aivle.auth.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import kt.aivle.auth.application.port.in.command.LoginCommand;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password,
+
+        String name,
+        String phoneNumber
+) {
+    public LoginCommand toCommand() {
+        return LoginCommand.builder()
+                .email(this.email)
+                .password(this.password)
+                .build();
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/SignUpRequest.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/SignUpRequest.java
@@ -1,0 +1,28 @@
+package kt.aivle.auth.adapter.in.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import kt.aivle.auth.application.port.in.command.SignUpCommand;
+
+public record SignUpRequest(
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        @NotBlank(message = "이메일을 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 50, message = "비밀번호는 8자 이상 50자 이하로 입력해주세요.")
+        String password,
+
+        String name,
+        String phoneNumber
+) {
+    public SignUpCommand toCommand() {
+        return SignUpCommand.builder()
+                .email(this.email)
+                .password(this.password)
+                .name(this.name)
+                .phoneNumber(this.phoneNumber)
+                .build();
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/JpaUserRepository.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/JpaUserRepository.java
@@ -3,6 +3,9 @@ package kt.aivle.auth.adapter.out.persistence;
 import kt.aivle.auth.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JpaUserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/JpaUserRepository.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/JpaUserRepository.java
@@ -1,0 +1,8 @@
+package kt.aivle.auth.adapter.out.persistence;
+
+import kt.aivle.auth.domain.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,23 @@
+package kt.aivle.auth.adapter.out.persistence;
+
+import kt.aivle.auth.application.port.out.UserRepositoryPort;
+import kt.aivle.auth.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements UserRepositoryPort {
+
+    private final JpaUserRepository userRepository;
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -2,8 +2,11 @@ package kt.aivle.auth.adapter.out.persistence;
 
 import kt.aivle.auth.application.port.out.UserRepositoryPort;
 import kt.aivle.auth.domain.model.User;
+import kt.aivle.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static kt.aivle.auth.exception.AuthErrorCode.NOT_FOUND_EMAIL;
 
 @Component
 @RequiredArgsConstructor
@@ -19,5 +22,10 @@ public class UserPersistenceAdapter implements UserRepositoryPort {
     @Override
     public User save(User user) {
         return userRepository.save(user);
+    }
+
+    @Override
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(NOT_FOUND_EMAIL));
     }
 }

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
@@ -1,7 +1,10 @@
 package kt.aivle.auth.application.port.in;
 
+import kt.aivle.auth.application.port.in.command.LoginCommand;
 import kt.aivle.auth.application.port.in.command.SignUpCommand;
 
 public interface AuthUseCase {
     void singUp(SignUpCommand command);
+
+    void login(LoginCommand command);
 }

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
@@ -1,0 +1,7 @@
+package kt.aivle.auth.application.port.in;
+
+import kt.aivle.auth.application.port.in.command.SignUpCommand;
+
+public interface AuthUseCase {
+    void singUp(SignUpCommand command);
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
@@ -1,10 +1,11 @@
 package kt.aivle.auth.application.port.in;
 
+import kt.aivle.auth.adapter.in.web.dto.AuthResponse;
 import kt.aivle.auth.application.port.in.command.LoginCommand;
 import kt.aivle.auth.application.port.in.command.SignUpCommand;
 
 public interface AuthUseCase {
-    void singUp(SignUpCommand command);
+    AuthResponse signUp(SignUpCommand command);
 
-    void login(LoginCommand command);
+    AuthResponse login(LoginCommand command);
 }

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/command/LoginCommand.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/command/LoginCommand.java
@@ -1,0 +1,7 @@
+package kt.aivle.auth.application.port.in.command;
+
+import lombok.Builder;
+
+@Builder
+public record LoginCommand(String email, String password) {
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/command/SignUpCommand.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/command/SignUpCommand.java
@@ -1,0 +1,7 @@
+package kt.aivle.auth.application.port.in.command;
+
+import lombok.Builder;
+
+@Builder
+public record SignUpCommand(String email, String password, String name, String phoneNumber) {
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/out/UserRepositoryPort.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/out/UserRepositoryPort.java
@@ -1,0 +1,9 @@
+package kt.aivle.auth.application.port.out;
+
+import kt.aivle.auth.domain.model.User;
+
+public interface UserRepositoryPort {
+    boolean existsByEmail(String email);
+
+    User save(User user);
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/out/UserRepositoryPort.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/out/UserRepositoryPort.java
@@ -6,4 +6,6 @@ public interface UserRepositoryPort {
     boolean existsByEmail(String email);
 
     User save(User user);
+
+    User findByEmail(String email);
 }

--- a/auth-service/src/main/java/kt/aivle/auth/application/service/UserLoginFailService.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/service/UserLoginFailService.java
@@ -1,0 +1,20 @@
+package kt.aivle.auth.application.service;
+
+import kt.aivle.auth.application.port.out.UserRepositoryPort;
+import kt.aivle.auth.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserLoginFailService {
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void increaseFailCount(User user) {
+        user.increaseLoginFailCount();
+        userRepositoryPort.save(user);
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/config/JpaConfig.java
+++ b/auth-service/src/main/java/kt/aivle/auth/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package kt.aivle.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/auth-service/src/main/java/kt/aivle/auth/config/SecurityConfig.java
+++ b/auth-service/src/main/java/kt/aivle/auth/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package kt.aivle.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/domain/model/User.java
+++ b/auth-service/src/main/java/kt/aivle/auth/domain/model/User.java
@@ -1,0 +1,56 @@
+package kt.aivle.auth.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import kt.aivle.common.entity.BaseEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class User extends BaseEntity {
+
+    private String provider;
+    private String providerId;
+
+    @Column(unique = true)
+    private String email;
+    private String name;
+    private String password;
+    private String phoneNumber;
+
+    private int loginFailCount = 0;
+    private boolean locked = false;
+
+    @Builder
+    public User(String provider, String providerId, String email, String name,
+                String password, String phoneNumber, int loginFailCount, boolean locked) {
+        this.provider = provider;
+        this.providerId = providerId;
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.loginFailCount = loginFailCount;
+        this.locked = locked;
+    }
+
+    public void increaseLoginFailCount() {
+        this.loginFailCount++;
+        if (this.loginFailCount >= 5) {
+            this.locked = true;
+        }
+    }
+
+    public void resetLoginFailCount() {
+        this.loginFailCount = 0;
+    }
+
+    public void unlock() {
+        this.locked = false;
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/domain/service/UserPasswordPolicy.java
+++ b/auth-service/src/main/java/kt/aivle/auth/domain/service/UserPasswordPolicy.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import java.util.regex.Pattern;
 
 @Service
-public class UserPasswordPolicyService {
+public class UserPasswordPolicy {
 
     // 허용 특수문자 집합 ( () < > “ ‘ ; 는 제외 )
     private static final String SPECIAL_CHARS = "!@#$%^&*_-+=|\\/?.,:[]{}";

--- a/auth-service/src/main/java/kt/aivle/auth/domain/service/UserPasswordPolicyService.java
+++ b/auth-service/src/main/java/kt/aivle/auth/domain/service/UserPasswordPolicyService.java
@@ -1,0 +1,61 @@
+package kt.aivle.auth.domain.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Pattern;
+
+@Service
+public class UserPasswordPolicyService {
+
+    // 허용 특수문자 집합 ( () < > “ ‘ ; 는 제외 )
+    private static final String SPECIAL_CHARS = "!@#$%^&*_-+=|\\/?.,:[]{}";
+    private static final Pattern SPECIAL_PATTERN = Pattern.compile("[" + Pattern.quote(SPECIAL_CHARS) + "]");
+    private static final Pattern UPPER_PATTERN = Pattern.compile("[A-Z]");
+    private static final Pattern LOWER_PATTERN = Pattern.compile("[a-z]");
+    private static final Pattern DIGIT_PATTERN = Pattern.compile("[0-9]");
+
+    public boolean isValid(String email, String password) {
+        // 1. 길이 및 조합 체크
+        if (!isValidLengthAndCombination(password)) return false;
+
+        // 2. 연속문자(3자리 이상) 체크
+        if (hasSequentialChars(password, 3)) return false;
+
+        // 3. 아이디와 동일(완전일치) 불가
+        if (email != null && email.equals(password)) return false;
+        return true;
+    }
+
+    private boolean isValidLengthAndCombination(String pw) {
+        int length = pw.length();
+        boolean hasUpper = UPPER_PATTERN.matcher(pw).find();
+        boolean hasLower = LOWER_PATTERN.matcher(pw).find();
+        boolean hasDigit = DIGIT_PATTERN.matcher(pw).find();
+        boolean hasSpecial = SPECIAL_PATTERN.matcher(pw).find();
+
+        int kinds = 0;
+        if (hasUpper || hasLower) kinds++; // 영문(대/소문자 중 하나만 있으면 1종)
+        if (hasDigit) kinds++;
+        if (hasSpecial) kinds++;
+
+        // 2종(영문+숫자, 영문+특수, 숫자+특수) 10자리 이상
+        if (kinds == 2 && length >= 10) return true;
+        // 3종(영문+숫자+특수) 8자리 이상
+        if (kinds == 3 && length >= 8) return true;
+
+        return false;
+    }
+
+    private boolean hasSequentialChars(String pw, int limit) {
+        for (int i = 0; i <= pw.length() - limit; i++) {
+            boolean ascending = true, descending = true;
+            for (int j = 0; j < limit - 1; j++) {
+                char c1 = pw.charAt(i + j), c2 = pw.charAt(i + j + 1);
+                if (c2 != c1 + 1) ascending = false;
+                if (c2 != c1 - 1) descending = false;
+            }
+            if (ascending || descending) return true;
+        }
+        return false;
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/exception/AuthErrorCode.java
+++ b/auth-service/src/main/java/kt/aivle/auth/exception/AuthErrorCode.java
@@ -1,0 +1,31 @@
+package kt.aivle.auth.exception;
+
+import kt.aivle.common.code.DefaultCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum AuthErrorCode implements DefaultCode {
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, false, "이미 가입된 이메일입니다."),
+    INVALID_PASSWORD_POLICY(HttpStatus.BAD_REQUEST, false, "비밀번호는 2종류(영문, 숫자, 특수문자) 이상 10자리, 3종류 8자리 이상이어야 하며, 개인정보/연속문자/이메일 등과 유사하거나 동일하지 않아야 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final boolean success;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return success;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/exception/AuthErrorCode.java
+++ b/auth-service/src/main/java/kt/aivle/auth/exception/AuthErrorCode.java
@@ -7,8 +7,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements DefaultCode {
 
+    // 회원가입
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, false, "이미 가입된 이메일입니다."),
-    INVALID_PASSWORD_POLICY(HttpStatus.BAD_REQUEST, false, "비밀번호는 2종류(영문, 숫자, 특수문자) 이상 10자리, 3종류 8자리 이상이어야 하며, 개인정보/연속문자/이메일 등과 유사하거나 동일하지 않아야 합니다.");
+    INVALID_PASSWORD_POLICY(HttpStatus.BAD_REQUEST, false, "비밀번호는 2종류(영문, 숫자, 특수문자) 이상 10자리, 3종류 8자리 이상이어야 하며, 개인정보/연속문자/이메일 등과 유사하거나 동일하지 않아야 합니다."),
+
+    // 로그인
+    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
+    NOT_MATCHES_PASSWORD(HttpStatus.UNAUTHORIZED, false, "비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED_EMAIL(HttpStatus.UNAUTHORIZED, false, "계정이 잠금되었습니다.");
 
     private final HttpStatus httpStatus;
     private final boolean success;

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,9 +7,15 @@ dependencies {
     // Web/API
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // 보안·인증
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/common/src/main/java/kt/aivle/common/code/CommonResponseCode.java
+++ b/common/src/main/java/kt/aivle/common/code/CommonResponseCode.java
@@ -13,9 +13,10 @@ public enum CommonResponseCode implements DefaultCode {
 
     // 실패
     BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, false,"요청한 리소스를 찾을 수 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, false, "요청한 리소스를 찾을 수 없습니다."),
     CONFLICT(HttpStatus.CONFLICT, false, "요청이 충돌했습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, false, "유효하지 않은 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final boolean success;

--- a/common/src/main/java/kt/aivle/common/jwt/JwtConfig.java
+++ b/common/src/main/java/kt/aivle/common/jwt/JwtConfig.java
@@ -1,0 +1,10 @@
+package kt.aivle.common.jwt;
+
+import kt.aivle.common.jwt.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtConfig {
+}

--- a/common/src/main/java/kt/aivle/common/jwt/JwtDto.java
+++ b/common/src/main/java/kt/aivle/common/jwt/JwtDto.java
@@ -1,0 +1,4 @@
+package kt.aivle.common.jwt;
+
+public record JwtDto(String accessToken, long accessTokenExpiration) {
+}

--- a/common/src/main/java/kt/aivle/common/jwt/JwtProperties.java
+++ b/common/src/main/java/kt/aivle/common/jwt/JwtProperties.java
@@ -1,0 +1,13 @@
+package kt.aivle.common.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secret;
+    private long expirationMs;
+}

--- a/common/src/main/java/kt/aivle/common/jwt/JwtUtils.java
+++ b/common/src/main/java/kt/aivle/common/jwt/JwtUtils.java
@@ -1,0 +1,73 @@
+package kt.aivle.common.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import kt.aivle.common.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import static kt.aivle.common.code.CommonResponseCode.INVALID_TOKEN;
+
+@Slf4j
+@Component
+public class JwtUtils {
+
+    private final JwtProperties jwtProperties;
+    private Key key;
+
+    public JwtUtils(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    @PostConstruct
+    protected void init() {
+        byte[] keyBytes = Base64.getDecoder().decode(jwtProperties.getSecret());
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // JWT AccessToken 발급
+    public JwtDto generateAccessToken(Long userId, String email) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getExpirationMs());
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("email", email)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return new JwtDto(token, expiry.getTime());
+    }
+
+    public void validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(INVALID_TOKEN, "토큰이 만료되었습니다.");
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(INVALID_TOKEN, "유효하지 않은 토큰: " + e.getMessage());
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
closes #3

## 📝 주요 구현 내용
### 1. 비밀번호 정책/검증
- 비밀번호 길이/복잡도 정책 구현
- 영문, 숫자, 특수문자 2종류 이상 조합 시 10자리 이상
-  3종류 조합 시 8자리 이상
- 특수문자 제한: ()<>“‘; 등 제외
-  계정(ID)과 비밀번호 동일 사용 금지
-  연속 숫자/개인정보(이메일, 전화번호 등) 포함 금지 (일부만 완료, 추후 개선 필요)

### 2. 비밀번호 암호화/전송
- 비밀번호 전송 시 암호화, 저장 시 해시 적용( 일방향(해시) 암호화 적용)
- Spring Security의 PasswordEncoder 사용

### 3. 로그인 실패/계정 잠금
- 5회 이상 로그인 실패 시 계정 잠금 처리
- 로그인 실패 횟수는 별도 서비스(@Transactional(REQUIRES_NEW))에서 관리
- 로그인 실패시 실패 카운트 증가 및 계정 잠금 처리
- 로그인 실패 횟수에 따른 로그인 지연시간 설정 (다음 이슈로 이관)

### 4. 회원가입/로그인 구조 개선
- Command-DTO 패턴 적용
- 요청(Request) → Command 변환
- 응답(Response) DTO 사용 (accessToken, 만료일 등 반환)
-  회원가입/로그인 성공 시 JWT accessToken, 만료일 함께 반환


### 5. JWT 발급/공통 모듈화
- 공통 모듈(common)에 JwtProperties, JwtUtils/JwtProvider 구현
 
### 6. 예외/응답 구조 개선
- 비즈니스 예외 처리(BusinessException) 통일
- 회원 미존재, 비밀번호 정책 미준수, 계정잠김 등 다양한 예외 상황에 대한 응답 메시지 명확화

## ⏭️ 다음 이슈로 이관할 작업
- 로그인 실패 횟수에 따른 로그인 지연시간 설정
- 연속적인 숫자/생일/전화번호 등 추측 쉬운 정보 포함 비밀번호 차단의 고도화
- 비밀번호 유효기간(반기별 1회 이상 변경)
- 본인 확인 수단 (이메일 검증 등)
- 계정 잠금 해제(이메일 검증/비밀번호 초기화)
- 아이디 찾기/비밀번호 찾기/비밀번호 재설정
- JWT 토큰 발급 외, refreshToken 발급 및 저장/관리 (별도 이슈 예정)
- 로그아웃 시 블랙리스트(JWT 무효화) 구현 (별도 이슈 예정)


## 💬 추가 참고 사항
- 이번 PR에서 추가된 비밀번호 정책/로그인 실패 처리, JWT 발급 등은 실무 보안 가이드/컴플라이언스 기준을 반영함
- 미완료된 항목은 팀 합의 후 후속 이슈에서 순차적으로 개발 예정