### PR TITLE
[issue # 5] RefreshToken 기반 JWT 인증/갱신 및 안전한 로그아웃 정책 강화

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // 요청 검증
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
@@ -9,10 +9,7 @@ import kt.aivle.common.response.ApiResponse;
 import kt.aivle.common.response.ResponseUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static kt.aivle.common.code.CommonResponseCode.CREATED;
 import static kt.aivle.common.code.CommonResponseCode.OK;
@@ -34,6 +31,13 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
         AuthResponse response = authUseCase.login(request.toCommand());
+        return responseUtils.build(OK, response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<AuthResponse>> refresh(@RequestHeader("Authorization") String authorizationHeader) {
+        String refreshToken = authorizationHeader.replaceFirst("^Bearer ", "");
+        AuthResponse response = authUseCase.refresh(refreshToken);
         return responseUtils.build(OK, response);
     }
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/AuthController.java
@@ -5,14 +5,14 @@ import kt.aivle.auth.adapter.in.web.dto.AuthResponse;
 import kt.aivle.auth.adapter.in.web.dto.LoginRequest;
 import kt.aivle.auth.adapter.in.web.dto.SignUpRequest;
 import kt.aivle.auth.application.port.in.AuthUseCase;
+import kt.aivle.auth.application.port.in.command.TokenCommand;
 import kt.aivle.common.response.ApiResponse;
 import kt.aivle.common.response.ResponseUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static kt.aivle.common.code.CommonResponseCode.CREATED;
-import static kt.aivle.common.code.CommonResponseCode.OK;
+import static kt.aivle.common.code.CommonResponseCode.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -35,9 +35,22 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<AuthResponse>> refresh(@RequestHeader("Authorization") String authorizationHeader) {
-        String refreshToken = authorizationHeader.replaceFirst("^Bearer ", "");
-        AuthResponse response = authUseCase.refresh(refreshToken);
+    public ResponseEntity<ApiResponse<AuthResponse>> refresh(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestHeader("X-Refresh-Token") String refreshToken
+    ) {
+        accessToken = accessToken.replace("Bearer ", "");
+        AuthResponse response = authUseCase.refresh(new TokenCommand(accessToken, refreshToken));
         return responseUtils.build(OK, response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestHeader("X-Refresh-Token") String refreshToken
+    ) {
+        accessToken = accessToken.replace("Bearer ", "");
+        authUseCase.logout(new TokenCommand(accessToken, refreshToken));
+        return responseUtils.build(NO_CONTENT, null);
     }
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/AuthResponse.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/in/web/dto/AuthResponse.java
@@ -3,5 +3,6 @@ package kt.aivle.auth.adapter.in.web.dto;
 import lombok.Builder;
 
 @Builder
-public record AuthResponse(String accessToken, long accessTokenExpiration) {
+public record AuthResponse(String type, String accessToken, long accessTokenExpiration,
+                           String refreshToken, long refreshTokenExpiration) {
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/persistence/UserPersistenceAdapter.java
@@ -2,11 +2,10 @@ package kt.aivle.auth.adapter.out.persistence;
 
 import kt.aivle.auth.application.port.out.UserRepositoryPort;
 import kt.aivle.auth.domain.model.User;
-import kt.aivle.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static kt.aivle.auth.exception.AuthErrorCode.NOT_FOUND_EMAIL;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -25,7 +24,12 @@ public class UserPersistenceAdapter implements UserRepositoryPort {
     }
 
     @Override
-    public User findByEmail(String email) {
-        return userRepository.findByEmail(email).orElseThrow(() -> new BusinessException(NOT_FOUND_EMAIL));
+    public Optional<User> findById(Long userId) {
+        return userRepository.findById(userId);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
     }
 }

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/redis/RefreshTokenRedisRepository.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/redis/RefreshTokenRedisRepository.java
@@ -1,0 +1,43 @@
+package kt.aivle.auth.adapter.out.redis;
+
+import kt.aivle.auth.application.port.out.RefreshTokenRepositoryPort;
+import kt.aivle.common.exception.InfraException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static kt.aivle.common.code.CommonResponseCode.INTERNAL_SERVER_ERROR;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisRepository implements RefreshTokenRepositoryPort {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String PREFIX = "refresh_token:";
+
+    @Override
+    public void save(Long userId, String refreshToken, long expiresInMillis) {
+        String key = PREFIX + refreshToken;
+        try {
+            redisTemplate.opsForValue().set(key, String.valueOf(userId), expiresInMillis, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            throw new InfraException(INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    @Override
+    public Optional<Long> findUserIdByToken(String refreshToken) {
+        String key = PREFIX + refreshToken;
+        String value = redisTemplate.opsForValue().get(key);
+        return (value != null) ? Optional.of(Long.parseLong(value)) : Optional.empty();
+    }
+
+    @Override
+    public void delete(String refreshToken) {
+        String key = PREFIX + refreshToken;
+        redisTemplate.delete(key);
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/adapter/out/redis/TokenBlackListRedisRepository.java
+++ b/auth-service/src/main/java/kt/aivle/auth/adapter/out/redis/TokenBlackListRedisRepository.java
@@ -1,0 +1,28 @@
+package kt.aivle.auth.adapter.out.redis;
+
+import kt.aivle.auth.application.port.out.TokenBlacklistRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class TokenBlackListRedisRepository implements TokenBlacklistRepositoryPort {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String PREFIX = "blacklist:access_token:";
+
+    @Override
+    public void addAccessTokenToBlacklist(String jti, long expirationMillis) {
+        String key = PREFIX + jti;
+        redisTemplate.opsForValue().set(key, "blacklisted", expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean isBlacklisted(String jti) {
+        String key = PREFIX + jti;
+        return redisTemplate.hasKey(key);
+    }
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
@@ -8,4 +8,6 @@ public interface AuthUseCase {
     AuthResponse signUp(SignUpCommand command);
 
     AuthResponse login(LoginCommand command);
+
+    AuthResponse refresh(String refreshToken);
 }

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/AuthUseCase.java
@@ -3,11 +3,14 @@ package kt.aivle.auth.application.port.in;
 import kt.aivle.auth.adapter.in.web.dto.AuthResponse;
 import kt.aivle.auth.application.port.in.command.LoginCommand;
 import kt.aivle.auth.application.port.in.command.SignUpCommand;
+import kt.aivle.auth.application.port.in.command.TokenCommand;
 
 public interface AuthUseCase {
     AuthResponse signUp(SignUpCommand command);
 
     AuthResponse login(LoginCommand command);
 
-    AuthResponse refresh(String refreshToken);
+    AuthResponse refresh(TokenCommand command);
+
+    void logout(TokenCommand command);
 }

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/in/command/TokenCommand.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/in/command/TokenCommand.java
@@ -1,0 +1,7 @@
+package kt.aivle.auth.application.port.in.command;
+
+import lombok.Builder;
+
+@Builder
+public record TokenCommand(String accessToken, String refreshToken) {
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/out/RefreshTokenRepositoryPort.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/out/RefreshTokenRepositoryPort.java
@@ -1,0 +1,11 @@
+package kt.aivle.auth.application.port.out;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepositoryPort {
+    void save(Long userId, String refreshToken, long expirationMs);
+
+    Optional<Long> findUserIdByToken(String refreshToken);
+
+    void delete(String refreshToken);
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/out/TokenBlacklistRepositoryPort.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/out/TokenBlacklistRepositoryPort.java
@@ -1,0 +1,7 @@
+package kt.aivle.auth.application.port.out;
+
+public interface TokenBlacklistRepositoryPort {
+    void addAccessTokenToBlacklist(String jti, long expirationMillis);
+
+    boolean isBlacklisted(String jti);
+}

--- a/auth-service/src/main/java/kt/aivle/auth/application/port/out/UserRepositoryPort.java
+++ b/auth-service/src/main/java/kt/aivle/auth/application/port/out/UserRepositoryPort.java
@@ -2,10 +2,16 @@ package kt.aivle.auth.application.port.out;
 
 import kt.aivle.auth.domain.model.User;
 
+import java.util.Optional;
+
 public interface UserRepositoryPort {
     boolean existsByEmail(String email);
 
     User save(User user);
 
-    User findByEmail(String email);
+    Optional<User> findById(Long userId);
+
+    Optional<User> findByEmail(String email);
+
+
 }

--- a/auth-service/src/main/java/kt/aivle/auth/exception/AuthErrorCode.java
+++ b/auth-service/src/main/java/kt/aivle/auth/exception/AuthErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements DefaultCode {
 
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
+
     // 회원가입
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, false, "이미 가입된 이메일입니다."),
     INVALID_PASSWORD_POLICY(HttpStatus.BAD_REQUEST, false, "비밀번호는 2종류(영문, 숫자, 특수문자) 이상 10자리, 3종류 8자리 이상이어야 하며, 개인정보/연속문자/이메일 등과 유사하거나 동일하지 않아야 합니다."),
@@ -14,7 +16,11 @@ public enum AuthErrorCode implements DefaultCode {
     // 로그인
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
     NOT_MATCHES_PASSWORD(HttpStatus.UNAUTHORIZED, false, "비밀번호가 일치하지 않습니다."),
-    UNAUTHORIZED_EMAIL(HttpStatus.UNAUTHORIZED, false, "계정이 잠금되었습니다.");
+    UNAUTHORIZED_EMAIL(HttpStatus.UNAUTHORIZED, false, "계정이 잠금되었습니다."),
+
+    // 재발급
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, false, "유효하지 않은 재발급 토큰입니다.");
+
 
     private final HttpStatus httpStatus;
     private final boolean success;

--- a/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
@@ -23,8 +23,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        log.error("서버 예외 발생: {}", e.getMessage(), e); // 스택트레이스 포함 로깅
+        log.error("서버 예외 발생: {}", e.getMessage(), e);
         return responseUtils.build(INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(InfraException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInfraException(InfraException e) {
+        log.error("인프라 예외 발생: {}", e.toString(), e);
+        return responseUtils.build(e.getCode());
     }
 
     @ExceptionHandler(BusinessException.class)

--- a/common/src/main/java/kt/aivle/common/exception/InfraException.java
+++ b/common/src/main/java/kt/aivle/common/exception/InfraException.java
@@ -1,0 +1,24 @@
+package kt.aivle.common.exception;
+
+import kt.aivle.common.code.DefaultCode;
+import lombok.Getter;
+
+@Getter
+public class InfraException extends RuntimeException {
+    private final DefaultCode code;
+
+    public InfraException(DefaultCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+
+    public InfraException(DefaultCode code, Throwable cause) {
+        super(code.getMessage(), cause);
+        this.code = code;
+    }
+
+    public InfraException(DefaultCode code, String customMessage) {
+        super(customMessage);
+        this.code = code;
+    }
+}

--- a/common/src/main/java/kt/aivle/common/jwt/JwtUtils.java
+++ b/common/src/main/java/kt/aivle/common/jwt/JwtUtils.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+import java.util.UUID;
 
 import static kt.aivle.common.code.CommonResponseCode.INVALID_TOKEN;
 
@@ -34,10 +35,12 @@ public class JwtUtils {
     public JwtDto generateAccessToken(Long userId, String email) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + jwtProperties.getExpirationMs());
+        String jti = UUID.randomUUID().toString();
 
         String token = Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .claim("email", email)
+                .setId(jti)
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(key, SignatureAlgorithm.HS256)
@@ -46,20 +49,7 @@ public class JwtUtils {
         return new JwtDto(token, expiry.getTime());
     }
 
-    public void validateToken(String token) {
-        try {
-            Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(token);
-        } catch (ExpiredJwtException e) {
-            throw new BusinessException(INVALID_TOKEN, "토큰이 만료되었습니다.");
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new BusinessException(INVALID_TOKEN, "유효하지 않은 토큰: " + e.getMessage());
-        }
-    }
-
-    private Claims parseClaims(String token) {
+    public Claims parseClaimsAllowExpired(String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)
@@ -68,6 +58,26 @@ public class JwtUtils {
                     .getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(INVALID_TOKEN, "유효하지 않은 토큰입니다.");
         }
+    }
+
+    public void validateToken(String token) {
+        Claims claims = parseClaimsAllowExpired(token);
+        if (claims.getExpiration().getTime() < System.currentTimeMillis()) {
+            throw new BusinessException(INVALID_TOKEN, "토큰이 만료되었습니다.");
+        }
+    }
+
+    public boolean isExpired(Claims claims) {
+        return claims.getExpiration().getTime() <= System.currentTimeMillis();
+    }
+
+    public String getJti(Claims claims) {
+        return claims.getId();
+    }
+    public long getExpiration(Claims claims) {
+        return claims.getExpiration().getTime();
     }
 }


### PR DESCRIPTION
## 1. 목표

- UUID 기반 RefreshToken 발급·저장  
- RefreshToken 롤링 방식 재발급(AccessToken 갱신)  
- 안전한 로그아웃(블랙리스트)  

## 2. 작업 세부 내역

### [A] RefreshToken 발급 및 저장
- 회원가입/로그인 시 UUID 기반 refreshToken 생성  
- Redis에 `refresh_token:{refreshToken}` = `{userId}` 로 저장 (만료시간 14일, TTL)  
- accessToken/refreshToken을 응답에 모두 내려줌  

### [B] AccessToken 재발급 (Refresh)
- 클라이언트는 refreshToken을 Authorization 헤더(`Bearer ...`)로 전달  
- 서버는 해당 refreshToken → userId를 Redis에서 조회  
- 없으면 `UNAUTHORIZED` 예외  
- userId 기반 유저 DB 조회 및 계정 상태 체크(탈퇴/잠금)  
- 새 accessToken, 새 refreshToken(롤링 방식) 모두 재발급하여 응답  
- Redis에 새로운 refreshToken 저장, 기존 refreshToken은 즉시 삭제  
  - (롤링 정책: 한 번 사용된 refreshToken은 즉시 폐기)  

### [C] 로그아웃 (RefreshToken 삭제)
- 클라이언트에서 로그아웃 시, 사용 중인 refreshToken을 서버에 전달  
- 해당 refreshToken을 Redis에서 즉시 삭제  
- 이후 해당 토큰으로 재발급 시도 시 `UNAUTHORIZED` 반환  

## 3. 정책 및 보안

- **롤링 & 즉시 폐기**: refreshToken 유출 리스크 최소화  
- **만료시간 14일**: 서버에서 TTL로 일괄 관리  
- **재사용 공격 방지**: 재발급 시 기존 토큰 무효화  
- **로그아웃 시 삭제**: 서버단 완전 삭제  

## 4. 추가 변경 사항
### [D] JwtUtils 리팩토링
- parseClaimsAllowExpired(token)
- 서명(Signature) 검증만 수행, 만료된 토큰은 ExpiredJwtException→Claims 반환
- parseClaims(token)
- 서명+만료 검증, 만료 시 BusinessException(INVALID_TOKEN)
- isExpired(Claims) 헬퍼 메서드 추가
- validateToken(token) → “완전 유효성” 검증용

### [F] AuthService 리팩토링
- blacklistIfNotExpired(Claims) 공통 로직 추출
