### PR TITLE
[store] 매장 도메인 개발 및 CI/CD 설정 (#24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,10 @@ jobs:
   filter:
     runs-on: ubuntu-latest
     outputs:
-      auth: ${{ steps.filter.outputs.auth }}
-      gateway: ${{ steps.filter.outputs.gateway }}
       compose: ${{ steps.filter.outputs.compose }}
+      gateway: ${{ steps.filter.outputs.gateway }}
+      auth: ${{ steps.filter.outputs.auth }}
+      store: ${{ steps.filter.outputs.store }}
     steps:
       - uses: actions/checkout@v4
 
@@ -19,13 +20,14 @@ jobs:
         uses: dorny/paths-filter@v3.0.2
         with:
           filters: |
-            auth:
-              - 'auth-service/**'
-            gateway:
-              - 'gateway/**'
             compose:
               - 'docker-compose.prod.yml'
-
+            gateway:
+              - 'gateway/**'
+            auth:
+              - 'auth-service/**'
+            store:
+              - 'store-service/**'
   upload-compose:
     needs: filter
     runs-on: ubuntu-latest
@@ -44,8 +46,57 @@ jobs:
           source: "docker-compose.yml"
           target: "/home/ubuntu/deploy/"
 
+  build-and-deploy-gateway:
+    needs: [ filter, upload-compose ]
+    if: ${{ needs.filter.outputs.gateway == 'true' || needs.filter.outputs.compose == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Create application.yml for gateway
+        run: |
+          mkdir -p ./gateway/src/main/resources
+          cat <<EOF > ./gateway/src/main/resources/application.yml
+          ${{ secrets.APPLICATION_YML_GATEWAY }}
+          EOF
+        shell: bash
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build gateway JAR
+        run: ./gradlew :gateway:clean :gateway:build
+
+      - name: Docker build & push (gateway)
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/aivle-gateway:latest ./gateway
+          docker push ${{ secrets.DOCKER_USERNAME }}/aivle-gateway:latest
+
+      - name: Deploy gateway to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_SECRET_HOST }}
+          username: ubuntu
+          key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          script: |
+            cd /home/ubuntu/deploy/
+            tmp_env=$(mktemp)
+            grep -v '^DOCKER_USERNAME=' .env > "$tmp_env" || true
+            echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> "$tmp_env"
+            mv "$tmp_env" .env
+            docker compose pull gateway
+            docker compose up -d gateway
+            docker image prune -f || true
+
   build-and-deploy-auth-service:
-    needs: [filter, upload-compose]
+    needs: [ filter, upload-compose ]
     if: ${{ needs.filter.outputs.auth == 'true' || needs.filter.outputs.compose == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -93,9 +144,9 @@ jobs:
             docker compose up -d auth-service
             docker image prune -f || true
 
-  build-and-deploy-gateway:
-    needs: [filter, upload-compose]
-    if: ${{ needs.filter.outputs.gateway == 'true' || needs.filter.outputs.compose == 'true' }}
+  build-and-deploy-store-service:
+    needs: [ filter, upload-compose ]
+    if: ${{ needs.filter.outputs.store == 'true' || needs.filter.outputs.compose == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -106,27 +157,27 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Create application.yml for gateway
+      - name: Create application.yml for store-service
         run: |
-          mkdir -p ./gateway/src/main/resources
-          cat <<EOF > ./gateway/src/main/resources/application.yml
-          ${{ secrets.APPLICATION_YML_GATEWAY }}
+          mkdir -p ./store-service/src/main/resources
+          cat <<EOF > ./store-service/src/main/resources/application.yml
+          ${{ secrets.APPLICATION_YML_STORE }}
           EOF
         shell: bash
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Build gateway JAR
-        run: ./gradlew :gateway:clean :gateway:build
+      - name: Build store-service JAR
+        run: ./gradlew :store-service:clean :store-service:build
 
-      - name: Docker build & push (gateway)
+      - name: Docker build & push (store-service)
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/aivle-gateway:latest ./gateway
-          docker push ${{ secrets.DOCKER_USERNAME }}/aivle-gateway:latest
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/aivle-store:latest ./store-service
+          docker push ${{ secrets.DOCKER_USERNAME }}/aivle-store:latest
 
-      - name: Deploy gateway to server
+      - name: Deploy store-service to server
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.AWS_SECRET_HOST }}
@@ -138,6 +189,6 @@ jobs:
             grep -v '^DOCKER_USERNAME=' .env > "$tmp_env" || true
             echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> "$tmp_env"
             mv "$tmp_env" .env
-            docker compose pull gateway
-            docker compose up -d gateway
+            docker compose pull store-service
+            docker compose up -d store-service
             docker image prune -f || true

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -12,9 +12,9 @@ dependencies {
 
     // 보안·인증
     implementation 'org.springframework.security:spring-security-crypto'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api'
+    implementation 'io.jsonwebtoken:jjwt-impl'
+    implementation 'io.jsonwebtoken:jjwt-jackson'
 
     // DB/JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -27,7 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -38,5 +38,15 @@ subprojects {
             mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.4"
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
         }
+        dependencies {
+            dependency "org.mapstruct:mapstruct:1.5.5.Final"
+            dependency "org.mapstruct:mapstruct-processor:1.5.5.Final"
+            dependency "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9"
+            dependency "org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9"
+            dependency 'io.jsonwebtoken:jjwt-api:0.11.5'
+            dependency "io.jsonwebtoken:jjwt-impl:0.11.5"
+            dependency "io.jsonwebtoken:jjwt-jackson:0.11.5"
+            dependency "org.projectlombok:lombok:1.18.38"
+        }
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,14 +12,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // 보안·인증
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api'
+    implementation 'io.jsonwebtoken:jjwt-impl'
+    implementation 'io.jsonwebtoken:jjwt-jackson'
 
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // Lombok
-    compileOnly 'org.projectlombok:lombok:1.18.38'
-    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }

--- a/common/src/main/java/kt/aivle/common/code/CommonResponseCode.java
+++ b/common/src/main/java/kt/aivle/common/code/CommonResponseCode.java
@@ -16,7 +16,8 @@ public enum CommonResponseCode implements DefaultCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, false, "요청한 리소스를 찾을 수 없습니다."),
     CONFLICT(HttpStatus.CONFLICT, false, "요청이 충돌했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, false, "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, false, "유효하지 않은 토큰입니다."),
+    BAD_REQUEST_MESSAGE(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다. 요청 형식이나 파라미터를 확인해주세요.");
 
     private final HttpStatus httpStatus;
     private final boolean success;

--- a/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
@@ -5,14 +5,14 @@ import kt.aivle.common.response.ResponseUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
-import static kt.aivle.common.code.CommonResponseCode.BAD_REQUEST;
-import static kt.aivle.common.code.CommonResponseCode.INTERNAL_SERVER_ERROR;
+import static kt.aivle.common.code.CommonResponseCode.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -46,5 +46,11 @@ public class GlobalExceptionHandler {
                 .map(err -> new FieldError(err.getField(), err.getDefaultMessage()))
                 .toList();
         return responseUtils.build(BAD_REQUEST, errors);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("HTTP 메시지 읽기 예외 발생: {}", e.getMessage(), e);
+        return responseUtils.build(BAD_REQUEST_MESSAGE);
     }
 }

--- a/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/kt/aivle/common/exception/GlobalExceptionHandler.java
@@ -48,6 +48,3 @@ public class GlobalExceptionHandler {
         return responseUtils.build(BAD_REQUEST, errors);
     }
 }
-
-
-

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,7 @@ services:
     container_name: gateway
     depends_on:
       - auth-service
+      - store-service
     environment:
       - SPRING_PROFILES_ACTIVE=prod
     ports:
@@ -16,6 +17,14 @@ services:
     container_name: auth-service
     depends_on:
       - redis
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+    networks:
+      - backend
+
+  store-service:
+    image: ${DOCKER_USERNAME}/aivle-store:latest
+    container_name: store-service
     environment:
       - SPRING_PROFILES_ACTIVE=prod
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,18 @@ services:
       - redis
     environment:
       - SPRING_PROFILES_ACTIVE=docker
-    ports:
-      - "8081:8080"
+    networks:
+      - backend
+
+  store-service:
+    build:
+      context: ./store-service
+      dockerfile: Dockerfile
+    container_name: store-service
+    depends_on:
+      - mysql
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
     networks:
       - backend
 
@@ -35,7 +45,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: userstore
-      MYSQL_USER: lee
+      MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       TZ: Asia/Seoul
     ports:
@@ -49,8 +59,6 @@ services:
     image: redis:7.2
     container_name: redis
     restart: always
-    ports:
-      - "6379:6379"
     networks:
       - backend
 

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -11,15 +11,15 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 
     // 보안·인증
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api'
+    implementation 'io.jsonwebtoken:jjwt-impl'
+    implementation 'io.jsonwebtoken:jjwt-jackson'
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/gateway/src/main/java/kt/aivle/gateway/config/ExcludePaths.java
+++ b/gateway/src/main/java/kt/aivle/gateway/config/ExcludePaths.java
@@ -20,7 +20,8 @@ public class ExcludePaths {
             "/swagger-resources/**",
             "/webjars/**",
             "/v3/api-docs/**",
-            "/api/auth/v3/api-docs/**"
+            "/api/auth/v3/api-docs/**",
+            "/api/stores/v3/api-docs/**"
     );
 
     public static boolean isPatternMatch(String path) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,4 @@ rootProject.name = 'marketing'
 include 'common'
 include 'auth-service'
 include 'gateway'
-
+include 'store-service'

--- a/store-service/Dockerfile
+++ b/store-service/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:17-jdk-alpine
+
+WORKDIR /app
+
+COPY build/libs/*SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar"]

--- a/store-service/build.gradle
+++ b/store-service/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+}
+
+dependencies {
+    // 공통 모듈
+    implementation project(':common')
+
+    // Web/API
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // DB/JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // 요청 검증
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct'
+    annotationProcessor 'org.mapstruct:mapstruct-processor'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/store-service/src/main/java/kt/aivle/store/StoreServiceApplication.java
+++ b/store-service/src/main/java/kt/aivle/store/StoreServiceApplication.java
@@ -1,0 +1,11 @@
+package kt.aivle.store;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {"kt.aivle.store", "kt.aivle.common"})
+public class StoreServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(StoreServiceApplication.class, args);
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/web/StoreController.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/web/StoreController.java
@@ -1,0 +1,75 @@
+package kt.aivle.store.adapter.in.web;
+
+import jakarta.validation.Valid;
+import kt.aivle.common.response.ApiResponse;
+import kt.aivle.common.response.ResponseUtils;
+import kt.aivle.store.adapter.in.web.dto.CreateStoreRequest;
+import kt.aivle.store.adapter.in.web.dto.StoreResponse;
+import kt.aivle.store.adapter.in.web.dto.UpdateStoreRequest;
+import kt.aivle.store.adapter.in.web.mapper.StoreCommandMapper;
+import kt.aivle.store.adapter.in.web.mapper.StoreQueryMapper;
+import kt.aivle.store.application.port.in.StoreUseCase;
+import kt.aivle.store.application.port.in.command.CreateStoreCommand;
+import kt.aivle.store.application.port.in.command.DeleteStoreCommand;
+import kt.aivle.store.application.port.in.command.UpdateStoreCommand;
+import kt.aivle.store.application.port.in.query.GetStoreQuery;
+import kt.aivle.store.application.port.in.query.GetStoresQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static kt.aivle.common.code.CommonResponseCode.CREATED;
+import static kt.aivle.common.code.CommonResponseCode.OK;
+
+@RestController
+@RequestMapping("/api/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreUseCase storeUseCase;
+    private final StoreCommandMapper storeCommandMapper;
+    private final StoreQueryMapper storeQueryMapper;
+    private final ResponseUtils responseUtils;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StoreResponse>>> getStores(@RequestHeader("X-USER-ID") Long userId) {
+        GetStoresQuery query = storeQueryMapper.toGetStoresQuery(userId);
+        List<StoreResponse> response = storeUseCase.getStores(query);
+        return responseUtils.build(OK, response);
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreResponse>> getStore(@RequestHeader("X-USER-ID") Long userId,
+                                                               @PathVariable Long storeId) {
+        GetStoreQuery query = storeQueryMapper.toGetStoreQuery(storeId, userId);
+        StoreResponse response = storeUseCase.getStore(query);
+        return responseUtils.build(OK, response);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoreResponse>> create(@RequestHeader("X-USER-ID") Long userId,
+                                                             @Valid @RequestBody CreateStoreRequest request) {
+        CreateStoreCommand command = storeCommandMapper.toCreateCommand(request, userId);
+        StoreResponse response = storeUseCase.createStore(command);
+        return responseUtils.build(CREATED, response);
+    }
+
+    @PatchMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<StoreResponse>> update(@RequestHeader("X-USER-ID") Long userId,
+                                                             @Valid @RequestBody UpdateStoreRequest request,
+                                                             @PathVariable Long storeId) {
+        UpdateStoreCommand updateCommand = storeCommandMapper.toUpdateCommand(request, storeId, userId);
+        StoreResponse response = storeUseCase.updateStore(updateCommand);
+        return responseUtils.build(OK, response);
+    }
+
+    @DeleteMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<Void>> delete(@RequestHeader("X-USER-ID") Long userId,
+                                                    @PathVariable Long storeId) {
+        DeleteStoreCommand command = storeCommandMapper.toDeleteCommand(storeId, userId);
+        storeUseCase.deleteStore(command);
+        return responseUtils.build(OK, null);
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/web/dto/CreateStoreRequest.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/web/dto/CreateStoreRequest.java
@@ -1,0 +1,27 @@
+package kt.aivle.store.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import kt.aivle.store.domain.model.Industry;
+
+public record CreateStoreRequest(
+        @NotBlank(message = "가게 이름을 입력해주세요.")
+        String name,
+
+        @NotBlank(message = "주소를 입력해주세요.")
+        String address,
+
+        @NotBlank(message = "연락처를 입력해주세요.")
+        @Pattern(regexp = "^(0\\d{1,2})-\\d{3,4}-\\d{4}$", message = "연락처 형식이 올바르지 않습니다.")
+        String phoneNumber,
+
+        String businessNumber,
+
+        Double latitude,
+        Double longitude,
+
+        @NotNull(message = "업종을 선택해주세요.")
+        Industry industry
+) {
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/web/dto/StoreResponse.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/web/dto/StoreResponse.java
@@ -1,0 +1,33 @@
+package kt.aivle.store.adapter.in.web.dto;
+
+import kt.aivle.store.domain.model.Industry;
+import kt.aivle.store.domain.model.Store;
+import lombok.Builder;
+
+@Builder
+public record StoreResponse(
+        Long id,
+        Long userId,
+        String name,
+        String address,
+        String phoneNumber,
+        String businessNumber,
+        Double latitude,
+        Double longitude,
+        Industry industry
+) {
+    public static StoreResponse from(Store store) {
+        return StoreResponse.builder()
+                .id(store.getId())
+                .userId(store.getUserId())
+                .name(store.getName())
+                .address(store.getAddress())
+                .phoneNumber(store.getPhoneNumber())
+                .businessNumber(store.getBusinessNumber())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .industry(store.getIndustry())
+                .build();
+    }
+}
+

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/web/dto/UpdateStoreRequest.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/web/dto/UpdateStoreRequest.java
@@ -1,0 +1,13 @@
+package kt.aivle.store.adapter.in.web.dto;
+
+import kt.aivle.store.domain.model.Industry;
+
+public record UpdateStoreRequest(
+        String name,
+        String address,
+        String phoneNumber,
+        Double latitude,
+        Double longitude,
+        Industry industry
+) {
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/web/mapper/StoreCommandMapper.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/web/mapper/StoreCommandMapper.java
@@ -1,0 +1,12 @@
+package kt.aivle.store.adapter.in.web.mapper;
+
+import kt.aivle.store.adapter.in.web.dto.*;
+import kt.aivle.store.application.port.in.command.*;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring")
+public interface StoreCommandMapper {
+    CreateStoreCommand toCreateCommand(CreateStoreRequest req, Long userId);
+    UpdateStoreCommand toUpdateCommand(UpdateStoreRequest req, Long id, Long userId);
+    DeleteStoreCommand toDeleteCommand(Long id, Long userId);
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/web/mapper/StoreQueryMapper.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/web/mapper/StoreQueryMapper.java
@@ -1,0 +1,12 @@
+package kt.aivle.store.adapter.in.web.mapper;
+
+import kt.aivle.store.application.port.in.query.GetStoreQuery;
+import kt.aivle.store.application.port.in.query.GetStoresQuery;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface StoreQueryMapper {
+    GetStoreQuery toGetStoreQuery(Long storeId, Long userId);
+
+    GetStoresQuery toGetStoresQuery(Long userId);
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/out/persistence/JpaStoreRepository.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/out/persistence/JpaStoreRepository.java
@@ -1,0 +1,11 @@
+package kt.aivle.store.adapter.out.persistence;
+
+
+import kt.aivle.store.domain.model.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JpaStoreRepository extends JpaRepository<Store, Long> {
+    List<Store> findAllByUserId(Long userId);
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/out/persistence/StorePersistenceAdapter.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/out/persistence/StorePersistenceAdapter.java
@@ -1,0 +1,36 @@
+package kt.aivle.store.adapter.out.persistence;
+
+import kt.aivle.store.application.port.out.StoreRepositoryPort;
+import kt.aivle.store.domain.model.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class StorePersistenceAdapter implements StoreRepositoryPort {
+
+    private final JpaStoreRepository storeRepository;
+
+    @Override
+    public Store save(Store store) {
+        return storeRepository.save(store);
+    }
+
+    @Override
+    public Optional<Store> findById(Long id) {
+        return storeRepository.findById(id);
+    }
+
+    @Override
+    public List<Store> findAllByUserId(Long userId) {
+        return storeRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public void delete(Store store) {
+        storeRepository.delete(store);
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/StoreUseCase.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/StoreUseCase.java
@@ -1,0 +1,22 @@
+package kt.aivle.store.application.port.in;
+
+import kt.aivle.store.adapter.in.web.dto.StoreResponse;
+import kt.aivle.store.application.port.in.command.CreateStoreCommand;
+import kt.aivle.store.application.port.in.command.DeleteStoreCommand;
+import kt.aivle.store.application.port.in.command.UpdateStoreCommand;
+import kt.aivle.store.application.port.in.query.GetStoreQuery;
+import kt.aivle.store.application.port.in.query.GetStoresQuery;
+
+import java.util.List;
+
+public interface StoreUseCase {
+    StoreResponse getStore(GetStoreQuery query);
+
+    List<StoreResponse> getStores(GetStoresQuery query);
+
+    StoreResponse createStore(CreateStoreCommand command);
+
+    StoreResponse updateStore(UpdateStoreCommand command);
+
+    void deleteStore(DeleteStoreCommand command);
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/command/CreateStoreCommand.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/command/CreateStoreCommand.java
@@ -1,0 +1,14 @@
+package kt.aivle.store.application.port.in.command;
+
+import kt.aivle.store.domain.model.Industry;
+
+public record CreateStoreCommand(
+        Long userId,
+        String name,
+        String address,
+        String phoneNumber,
+        String businessNumber,
+        Double latitude,
+        Double longitude,
+        Industry industry
+) {}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/command/DeleteStoreCommand.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/command/DeleteStoreCommand.java
@@ -1,0 +1,4 @@
+package kt.aivle.store.application.port.in.command;
+
+public record DeleteStoreCommand(Long id, Long userId) {
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/command/UpdateStoreCommand.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/command/UpdateStoreCommand.java
@@ -1,0 +1,15 @@
+package kt.aivle.store.application.port.in.command;
+
+import kt.aivle.store.domain.model.Industry;
+
+public record UpdateStoreCommand(
+        Long id,
+        Long userId,
+        String name,
+        String address,
+        String phoneNumber,
+        Double latitude,
+        Double longitude,
+        Industry industry
+) {
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/query/GetStoreQuery.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/query/GetStoreQuery.java
@@ -1,0 +1,4 @@
+package kt.aivle.store.application.port.in.query;
+
+public record GetStoreQuery(Long storeId, Long userId) {
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/query/GetStoresQuery.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/query/GetStoresQuery.java
@@ -1,0 +1,4 @@
+package kt.aivle.store.application.port.in.query;
+
+public record GetStoresQuery(Long userId) {
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/out/StoreRepositoryPort.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/out/StoreRepositoryPort.java
@@ -1,0 +1,16 @@
+package kt.aivle.store.application.port.out;
+
+import kt.aivle.store.domain.model.Store;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StoreRepositoryPort {
+    Store save(Store store);
+
+    Optional<Store> findById(Long id);
+
+    List<Store> findAllByUserId(Long userId);
+
+    void delete(Store store);
+}

--- a/store-service/src/main/java/kt/aivle/store/application/service/StoreService.java
+++ b/store-service/src/main/java/kt/aivle/store/application/service/StoreService.java
@@ -1,0 +1,106 @@
+package kt.aivle.store.application.service;
+
+import kt.aivle.common.exception.BusinessException;
+import kt.aivle.store.adapter.in.web.dto.StoreResponse;
+import kt.aivle.store.application.port.in.StoreUseCase;
+import kt.aivle.store.application.port.in.command.CreateStoreCommand;
+import kt.aivle.store.application.port.in.command.DeleteStoreCommand;
+import kt.aivle.store.application.port.in.command.UpdateStoreCommand;
+import kt.aivle.store.application.port.in.query.GetStoreQuery;
+import kt.aivle.store.application.port.in.query.GetStoresQuery;
+import kt.aivle.store.application.port.out.StoreRepositoryPort;
+import kt.aivle.store.domain.model.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static kt.aivle.store.exception.StoreErrorCode.NOT_AUTHORITY;
+import static kt.aivle.store.exception.StoreErrorCode.NOT_FOUND_STORE;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService implements StoreUseCase {
+
+    private final StoreRepositoryPort storeRepositoryPort;
+
+    @Transactional(readOnly = true)
+    @Override
+    public StoreResponse getStore(GetStoreQuery query) {
+        Store store = storeRepositoryPort.findById(query.storeId())
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_STORE));
+
+        if (isNotOwner(store, query.userId())) {
+            throw new BusinessException(NOT_AUTHORITY);
+        }
+
+        return StoreResponse.from(store);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<StoreResponse> getStores(GetStoresQuery query) {
+        List<Store> stores = storeRepositoryPort.findAllByUserId(query.userId());
+        return stores.stream().map(StoreResponse::from).toList();
+    }
+
+    @Transactional
+    @Override
+    public StoreResponse createStore(CreateStoreCommand command) {
+        Store store = Store.builder()
+                .userId(command.userId())
+                .name(command.name())
+                .address(command.address())
+                .phoneNumber(command.phoneNumber())
+                .businessNumber(command.businessNumber())
+                .latitude(command.latitude())
+                .longitude(command.longitude())
+                .industry(command.industry())
+                .build();
+
+        Store saved = storeRepositoryPort.save(store);
+
+        return StoreResponse.from(saved);
+    }
+
+    @Transactional
+    @Override
+    public StoreResponse updateStore(UpdateStoreCommand command) {
+        Store store = storeRepositoryPort.findById(command.id())
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_STORE));
+
+        if (isNotOwner(store, command.userId())) {
+            throw new BusinessException(NOT_AUTHORITY);
+        }
+
+        store.update(
+                command.name(),
+                command.address(),
+                command.phoneNumber(),
+                command.latitude(),
+                command.longitude(),
+                command.industry()
+        );
+
+        Store updated = storeRepositoryPort.save(store);
+        return StoreResponse.from(updated);
+    }
+
+    @Transactional
+    @Override
+    public void deleteStore(DeleteStoreCommand command) {
+        Store store = storeRepositoryPort.findById(command.id())
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_STORE));
+
+        if (isNotOwner(store, command.userId())) {
+            throw new BusinessException(NOT_AUTHORITY);
+        }
+
+        storeRepositoryPort.delete(store);
+    }
+
+    private boolean isNotOwner(Store store, Long userId) {
+        return !store.getUserId().equals(userId);
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/config/JpaConfig.java
+++ b/store-service/src/main/java/kt/aivle/store/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package kt.aivle.store.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/store-service/src/main/java/kt/aivle/store/config/SwaggerConfig.java
+++ b/store-service/src/main/java/kt/aivle/store/config/SwaggerConfig.java
@@ -1,0 +1,52 @@
+package kt.aivle.store.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(new Info().title("Store Service API").version("v0.0.1"))
+                .components(
+                        new io.swagger.v3.oas.models.Components()
+                                .addSecuritySchemes("bearerAuth", securityScheme)
+                )
+                .security(List.of(securityRequirement));
+    }
+
+    @Bean
+    public OpenApiCustomizer removeUserIdHeader() {
+        return openApi -> {
+            openApi.getPaths().values()
+                    .forEach(pathItem ->
+                            pathItem.readOperations()
+                                    .forEach(op -> {
+                                        List<io.swagger.v3.oas.models.parameters.Parameter> params = op.getParameters();
+                                        if (params != null) {
+                                            params.removeIf(p -> "X-USER-ID".equals(p.getName()));
+                                        }
+                                    })
+                    );
+        };
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/domain/model/Industry.java
+++ b/store-service/src/main/java/kt/aivle/store/domain/model/Industry.java
@@ -1,0 +1,36 @@
+package kt.aivle.store.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Industry {
+    AGRICULTURE("A", "농업, 임업 및 어업"),
+    MINING("B", "광업"),
+    MANUFACTURING("C", "제조업"),
+    ELECTRICITY("D", "전기, 가스, 증기 및 공기조절"),
+    WATER("E", "수도, 하수, 폐기물 관리"),
+    CONSTRUCTION("F", "건설업"),
+    RETAIL("G", "도매 및 소매업"),
+    TRANSPORT("H", "운수 및 창고업"),
+    FOOD("I", "숙박 및 음식점업"),
+    ICT("J", "정보통신업"),
+    FINANCE("K", "금융 및 보험업"),
+    REAL_ESTATE("L", "부동산업"),
+    PROFESSIONAL("M", "전문, 과학 및 기술 서비스업"),
+    BUSINESS("N", "사업시설관리 및 지원 서비스업"),
+    PUBLIC("O", "공공행정, 국방"),
+    EDUCATION("P", "교육서비스업"),
+    HEALTH("Q", "보건 및 사회복지 서비스업"),
+    CULTURE("R", "예술, 스포츠 및 여가"),
+    PERSONAL("S", "수리 및 기타 개인 서비스업"),
+    HOUSEHOLD("T", "가구 내 고용활동 등"),
+    FOREIGN("U", "국제 및 외국기관"),
+    ETC("ETC", "기타");
+
+    private final String code;
+    private final String label;
+}
+
+

--- a/store-service/src/main/java/kt/aivle/store/domain/model/Store.java
+++ b/store-service/src/main/java/kt/aivle/store/domain/model/Store.java
@@ -1,0 +1,52 @@
+package kt.aivle.store.domain.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import kt.aivle.common.entity.BaseEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Store extends BaseEntity {
+
+    private Long userId;
+    private String name;
+    private String address;
+    private String phoneNumber;
+    private String businessNumber;
+    private Double latitude;
+    private Double longitude;
+
+    @Enumerated(EnumType.STRING)
+    private Industry industry;
+
+    @Builder
+    public Store(Long userId, String name, String address, String phoneNumber,
+                 String businessNumber, Double latitude, Double longitude, Industry industry) {
+        this.userId = userId;
+        this.name = name;
+        this.address = address;
+        this.phoneNumber = phoneNumber;
+        this.businessNumber = businessNumber;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.industry = industry;
+    }
+
+    public void update(String name, String address, String phoneNumber,
+                       Double latitude, Double longitude,
+                       Industry industry) {
+        if (name != null) this.name = name;
+        if (address != null) this.address = address;
+        if (phoneNumber != null) this.phoneNumber = phoneNumber;
+        if (latitude != null) this.latitude = latitude;
+        if (longitude != null) this.longitude = longitude;
+        if (industry != null) this.industry = industry;
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/exception/StoreErrorCode.java
+++ b/store-service/src/main/java/kt/aivle/store/exception/StoreErrorCode.java
@@ -1,0 +1,31 @@
+package kt.aivle.store.exception;
+
+import kt.aivle.common.code.DefaultCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum StoreErrorCode implements DefaultCode {
+
+    NOT_FOUND_STORE(HttpStatus.NOT_FOUND, false, "매장을 찾을 수 없습니다."),
+    NOT_AUTHORITY(HttpStatus.FORBIDDEN, false, "권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final boolean success;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return success;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## 1. 환경설정
- settings.gradle 에 store 모듈 추가
- JPA, Swagger 의존성 추가 및 설정
- 공통 예외 처리용 StoreErrorCode enum 정의

## 2. 매장 CRUD API 개발
### 엔드포인트
- POST /api/stores : 매장 등록
- PUT /api/stores/{id} : 매장 수정
- DELETE /api/stores/{id} : 매장 삭제
- GET /api/stores/{id} : 매장 조회

### 구현 내역
- DTO ↔ Command/Query ↔ Domain 매핑 (mapper)
- Store 도메인 클래스 및 서비스/UseCase 로직
- API 레이어 요청/응답 스키마와 예외 처리

## 3. Gateway 연동
- Spring Cloud Gateway application.yml 에 store-service 라우팅 추가
- Swagger 문서 경로 연동 (Gateway에서 store 모듈 API 문서 노출)

## 4. Docker 설정
- store-service/Dockerfile 생성
- 루트 docker-compose.yml 에 store-service 서비스 정의 추가

## 5. CI/CD
- .github/workflows/deploy.yml 에 store-service 배포 단계(이미지 빌드 → 서버 배포) 로직 추가

