### PR TITLE
[store] Kafka 기반 매장 정보 이벤트 송수신 기능 추가 (#30)

### DIFF
--- a/store-service/build.gradle
+++ b/store-service/build.gradle
@@ -27,5 +27,8 @@ dependencies {
     implementation 'org.mapstruct:mapstruct'
     annotationProcessor 'org.mapstruct:mapstruct-processor'
 
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/event/StoreInfoEventConsumer.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/event/StoreInfoEventConsumer.java
@@ -1,0 +1,27 @@
+package kt.aivle.store.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kt.aivle.common.exception.InfraException;
+import kt.aivle.store.application.port.in.StoreEventUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import static kt.aivle.store.exception.StoreErrorCode.KFKA_ERROR;
+
+@Component
+@RequiredArgsConstructor
+public class StoreInfoEventConsumer {
+    private final StoreEventUseCase useCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "store.info.request", groupId = "store-group")
+    public void listen(String message) {
+        try {
+            StoreInfoRequestEvent event = objectMapper.readValue(message, StoreInfoRequestEvent.class);
+            useCase.handleStoreInfoRequest(event);
+        } catch (Exception e) {
+            throw new InfraException(KFKA_ERROR, e);
+        }
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/event/StoreInfoEventConsumer.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/event/StoreInfoEventConsumer.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-import static kt.aivle.store.exception.StoreErrorCode.KFKA_ERROR;
+import static kt.aivle.store.exception.StoreErrorCode.KAFKA_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -21,7 +21,7 @@ public class StoreInfoEventConsumer {
             StoreInfoRequestEvent event = objectMapper.readValue(message, StoreInfoRequestEvent.class);
             useCase.handleStoreInfoRequest(event);
         } catch (Exception e) {
-            throw new InfraException(KFKA_ERROR, e);
+            throw new InfraException(KAFKA_ERROR, e);
         }
     }
 }

--- a/store-service/src/main/java/kt/aivle/store/adapter/in/event/StoreInfoRequestEvent.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/in/event/StoreInfoRequestEvent.java
@@ -1,0 +1,4 @@
+package kt.aivle.store.adapter.in.event;
+
+public record StoreInfoRequestEvent(String requestId, Long storeId) {
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/out/event/StoreInfoEventProducer.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/out/event/StoreInfoEventProducer.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-import static kt.aivle.store.exception.StoreErrorCode.KFKA_ERROR;
+import static kt.aivle.store.exception.StoreErrorCode.KAFKA_ERROR;
 
 @Component
 @RequiredArgsConstructor
@@ -19,7 +19,7 @@ public class StoreInfoEventProducer {
             String json = objectMapper.writeValueAsString(event);
             kafkaTemplate.send("store.info.response", json);
         } catch (Exception e) {
-            throw new InfraException(KFKA_ERROR, e);
+            throw new InfraException(KAFKA_ERROR, e);
         }
     }
 }

--- a/store-service/src/main/java/kt/aivle/store/adapter/out/event/StoreInfoEventProducer.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/out/event/StoreInfoEventProducer.java
@@ -1,0 +1,25 @@
+package kt.aivle.store.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kt.aivle.common.exception.InfraException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import static kt.aivle.store.exception.StoreErrorCode.KFKA_ERROR;
+
+@Component
+@RequiredArgsConstructor
+public class StoreInfoEventProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void send(StoreInfoResponseEvent event) {
+        try {
+            String json = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send("store.info.response", json);
+        } catch (Exception e) {
+            throw new InfraException(KFKA_ERROR, e);
+        }
+    }
+}

--- a/store-service/src/main/java/kt/aivle/store/adapter/out/event/StoreInfoResponseEvent.java
+++ b/store-service/src/main/java/kt/aivle/store/adapter/out/event/StoreInfoResponseEvent.java
@@ -1,0 +1,16 @@
+package kt.aivle.store.adapter.out.event;
+
+import lombok.Builder;
+
+@Builder
+public record StoreInfoResponseEvent(
+        String requestId,
+        Long storeId,
+        String name,
+        String address,
+        String phoneNumber,
+        Double latitude,
+        Double longitude,
+        String industry
+) {
+}

--- a/store-service/src/main/java/kt/aivle/store/application/port/in/StoreEventUseCase.java
+++ b/store-service/src/main/java/kt/aivle/store/application/port/in/StoreEventUseCase.java
@@ -1,0 +1,7 @@
+package kt.aivle.store.application.port.in;
+
+import kt.aivle.store.adapter.in.event.StoreInfoRequestEvent;
+
+public interface StoreEventUseCase {
+    void handleStoreInfoRequest(StoreInfoRequestEvent event);
+}

--- a/store-service/src/main/java/kt/aivle/store/application/service/StoreEventService.java
+++ b/store-service/src/main/java/kt/aivle/store/application/service/StoreEventService.java
@@ -1,0 +1,40 @@
+package kt.aivle.store.application.service;
+
+import kt.aivle.common.exception.BusinessException;
+import kt.aivle.store.adapter.in.event.StoreInfoRequestEvent;
+import kt.aivle.store.adapter.out.event.StoreInfoEventProducer;
+import kt.aivle.store.adapter.out.event.StoreInfoResponseEvent;
+import kt.aivle.store.application.port.in.StoreEventUseCase;
+import kt.aivle.store.application.port.out.StoreRepositoryPort;
+import kt.aivle.store.domain.model.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static kt.aivle.store.exception.StoreErrorCode.NOT_FOUND_STORE;
+
+@Service
+@RequiredArgsConstructor
+public class StoreEventService implements StoreEventUseCase {
+
+    private final StoreRepositoryPort storeRepositoryPort;
+    private final StoreInfoEventProducer eventProducer;
+
+    @Override
+    public void handleStoreInfoRequest(StoreInfoRequestEvent event) {
+        Store store = storeRepositoryPort.findById(event.storeId())
+                .orElseThrow(() -> new BusinessException(NOT_FOUND_STORE));
+
+        StoreInfoResponseEvent responseEvent = StoreInfoResponseEvent.builder()
+                .storeId(store.getId())
+                .name(store.getName())
+                .address(store.getAddress())
+                .phoneNumber(store.getPhoneNumber())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .industry(store.getIndustry().name())
+                .requestId(event.requestId())
+                .build();
+        eventProducer.send(responseEvent);
+    }
+}
+

--- a/store-service/src/main/java/kt/aivle/store/exception/StoreErrorCode.java
+++ b/store-service/src/main/java/kt/aivle/store/exception/StoreErrorCode.java
@@ -9,7 +9,7 @@ public enum StoreErrorCode implements DefaultCode {
 
     NOT_FOUND_STORE(HttpStatus.NOT_FOUND, false, "매장을 찾을 수 없습니다."),
     NOT_AUTHORITY(HttpStatus.FORBIDDEN, false, "권한이 없습니다."),
-    KFKA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "카프카 통신에 실패했습니다.");
+    KAFKA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "카프카 통신에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final boolean success;

--- a/store-service/src/main/java/kt/aivle/store/exception/StoreErrorCode.java
+++ b/store-service/src/main/java/kt/aivle/store/exception/StoreErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum StoreErrorCode implements DefaultCode {
 
     NOT_FOUND_STORE(HttpStatus.NOT_FOUND, false, "매장을 찾을 수 없습니다."),
-    NOT_AUTHORITY(HttpStatus.FORBIDDEN, false, "권한이 없습니다.");
+    NOT_AUTHORITY(HttpStatus.FORBIDDEN, false, "권한이 없습니다."),
+    KFKA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "카프카 통신에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final boolean success;


### PR DESCRIPTION
## 관련 이슈
- closes #30 

## 📦 주요 변경 사항
- Kafka 기반 매장 정보 조회/응답 이벤트 송수신 로직 구현
- store.info.request 토픽 수신 Consumer(StoreInfoEventConsumer) 추가
-  store.info.response 토픽 발행 Producer(StoreInfoEventProducer) 추가
- 요청/응답 이벤트 DTO(StoreInfoRequestEvent, StoreInfoResponseEvent) 정의
- 매장 정보 요청 이벤트 처리 UseCase(Service) 분리(StoreEventUseCase)

## Kafka 접속 설정
- 도커 환경에서 컨테이너 간 연결이 되도록 kafka:9092로 bootstrap-server 환경변수 적용
- 응답 메시지 구조에 requestId 식별자 포함
- 복수 서비스 대응, 트래킹 및 분기 처리 용이하도록 설계

## 🗂️ 주요 파일
### adapter/in/event/StoreInfoEventConsumer.java
→ store.info.request 토픽 수신 및 이벤트 파싱, UseCase 호출

### adapter/out/event/StoreInfoEventProducer.java
→ store.info.response 토픽 발행, 직렬화 처리

### adapter/in/event/StoreInfoRequestEvent.java
### adapter/out/event/StoreInfoResponseEvent.java
→ 이벤트 메시지 DTO

### application/port/in/StoreEventUseCase.java,
### application/service/StoreEventService.java
→ 이벤트 처리 비즈니스 로직

## 🧪 테스트
- Kafka CLI 도구로 직접 토픽 발행/수신 테스트
- store.info.request에 JSON 메시지 발행 시, store.info.response에 응답 메시지 정상 수신 확인