### PR TITLE
[content] refactor: 콘텐츠 목록 조회 API 수정

### DIFF
--- a/content-service/src/main/java/kt/aivle/content/controller/BuildCookie.java
+++ b/content-service/src/main/java/kt/aivle/content/controller/BuildCookie.java
@@ -11,23 +11,28 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class BuildCookie {
 
-    @Value("${cdn.domain}")
-    private String cdnDomain;
+    @Value("${cdn.cookie-domain}")
+    private String cookieDomain;
 
     @Value("${cdn.ttl}")
     private int cookieTtl;
 
-    public ResponseCookie buildCfCookie(String nameEqValue, String thumbPrefix) {
+    public String buildCfCookieHeader(String nameEqValue, String cookiePath) {
         int i = nameEqValue.indexOf('=');
         String name = nameEqValue.substring(0, i);
         String value = nameEqValue.substring(i + 1);
-        return ResponseCookie.from(name, value)
-                .domain(cdnDomain)
-                .path(thumbPrefix)
+
+        String normalizedPath = cookiePath.startsWith("/") ? cookiePath : "/" + cookiePath;
+
+        ResponseCookie base = ResponseCookie.from(name, value)
+                .domain(cookieDomain)
+                .path(normalizedPath)
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
                 .maxAge(Duration.ofSeconds(cookieTtl))
                 .build();
+
+        return base.toString() + "; Partitioned";
     }
 }

--- a/content-service/src/main/java/kt/aivle/content/controller/ContentController.java
+++ b/content-service/src/main/java/kt/aivle/content/controller/ContentController.java
@@ -10,7 +10,6 @@ import kt.aivle.content.infra.CloudFrontSigner;
 import kt.aivle.content.service.ContentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,14 +68,14 @@ public class ContentController {
         GetContentListRequest request = contentMapper.toGetContentListRequest(userId, storeId, query);
         List<ContentResponse> response = contentService.getContents(request);
 
-        ResponseCookie sig = buildCookie.buildCfCookie(cookies.signatureHeaderValue(), cookiePath);
-        ResponseCookie kpid = buildCookie.buildCfCookie(cookies.keyPairIdHeaderValue(), cookiePath);
-        ResponseCookie pol = buildCookie.buildCfCookie(cookies.policyHeaderValue(), cookiePath);
+        String sig = buildCookie.buildCfCookieHeader(cookies.signatureHeaderValue(), cookiePath);
+        String kpid = buildCookie.buildCfCookieHeader(cookies.keyPairIdHeaderValue(), cookiePath);
+        String pol = buildCookie.buildCfCookieHeader(cookies.policyHeaderValue(), cookiePath);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.SET_COOKIE, sig.toString());
-        headers.add(HttpHeaders.SET_COOKIE, kpid.toString());
-        headers.add(HttpHeaders.SET_COOKIE, pol.toString());
+        headers.add(HttpHeaders.SET_COOKIE, sig);
+        headers.add(HttpHeaders.SET_COOKIE, kpid);
+        headers.add(HttpHeaders.SET_COOKIE, pol);
 
         return responseUtils.build(OK, response, headers);
     }


### PR DESCRIPTION
- 쿠키 서명에서 domain이 맞지 않아 해결이 안됨 실제로 도메인 하나 파고 서브 도메인으로 cdn.{도메인} 해서 적용